### PR TITLE
Correct "installing" paragraph that does not hold true anymore

### DIFF
--- a/docs-content/installing.html.md.erb
+++ b/docs-content/installing.html.md.erb
@@ -54,7 +54,7 @@ Use **Errands** to configure the lifecycle errands that run when you install or 
 #### Post-Deploy Errands
 
  * **Run BOSH Configurator**:
-	This errand configures a9s BOSH for PCF so that it can provision Redis service instances. When enabled, this errand uploads the required stemcells in the BOSH release. Disabling this errand may speed up the deployment of all tiles.
+	This errand configures a9s BOSH for PCF so that it can provision Redis service instances. When enabled, this errand uploads the required releases in the a9s BOSH Director. Disabling this errand may speed up the deployment of all tiles.
 
 	<p class="note"><strong>Note</strong>: To ensure your configuration remains up-to-date, disable this errand only when necessary.</p>
 


### PR DESCRIPTION
This changes the explanation in the BOSH errand paragraph, since the … stemcells have been removed from the tiles – but the task still uploads the releases on which it depends.